### PR TITLE
fix: switch default Bref v3 catalog to stable 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0](https://github.com/psantus/terraform-null-bref-layer/releases/tag/v1.2.0) (2026-02-27)
+
+### Fixes
+
+* Switch default Bref v3 runtime catalog from `3.0.0-beta2` to stable `3.0.0`.
+* Update README and v3 example override URL to stable catalog.
+
 ## [1.1.0](https://github.com/psantus/terraform-null-bref-layer/releases/tag/v1.1.0) (2026-01-13)
 
 ### Features
@@ -27,4 +34,3 @@ All notable changes to this project will be documented in this file.
 * *PHP Extensions Support**: Supports up to 9 PHP extensions from Bref's extra extensions
 * *Region Aware**: Automatically detects the current AWS region or accepts a custom region
 * *Combined Layer Arrays**: Provides ready-to-use arrays combining runtime and extension layers
-

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ module "bref_layers_v3" {
   aws_region  = "eu-central-1"
 
   # Override to pin a newer Bref v3 catalog if needed.
-  # bref_catalog_url = "https://raw.githubusercontent.com/brefphp/bref/3.0.0-beta2/layers.json"
+  # bref_catalog_url = "https://raw.githubusercontent.com/brefphp/bref/refs/tags/3.0.0/layers.json"
 }
 ```
 
@@ -228,7 +228,7 @@ echo "Running console command\n";
 
 This module uses the HTTP data source to fetch the latest layer versions from:
 - `https://raw.githubusercontent.com/brefphp/bref/refs/tags/2.4.16/layers.json` (v2 runtime catalog)
-- `https://raw.githubusercontent.com/brefphp/bref/refs/tags/3.0.0-beta2/layers.json` (v3 runtime catalog, override via `bref_catalog_url`)
+- `https://raw.githubusercontent.com/brefphp/bref/refs/tags/3.0.0/layers.json` (v3 runtime catalog, override via `bref_catalog_url`)
 - `https://raw.githubusercontent.com/brefphp/extra-php-extensions/refs/tags/1.8.6/layers.json` (v2 extensions)
 
 ## Error Handling

--- a/data.tf
+++ b/data.tf
@@ -22,7 +22,7 @@ locals {
   bref_layer_name_prefix = var.bref_layer_name_prefix != null ? var.bref_layer_name_prefix : ""
   bref_catalog_url = var.bref_catalog_url != null ? var.bref_catalog_url : (
     local.bref_major == 3
-    ? "https://raw.githubusercontent.com/brefphp/bref/refs/tags/3.0.0-beta2/layers.json"
+    ? "https://raw.githubusercontent.com/brefphp/bref/refs/tags/3.0.0/layers.json"
     : "https://raw.githubusercontent.com/brefphp/bref/refs/tags/2.4.16/layers.json"
   )
   php_version_normalized = replace(replace(lower(var.php_version), "php-", ""), ".", "")
@@ -32,11 +32,11 @@ locals {
   extension_versions = jsondecode(data.http.bref_extensions.response_body)
 
   # Generate layer keys based on CPU type and PHP version
-  cpu_prefix            = var.cpu_type == "arm64" ? "arm-" : ""
-  runtime_layer_key     = "${local.bref_layer_name_prefix}${local.cpu_prefix}php-${local.php_version_normalized}"
-  function_layer_key    = local.runtime_layer_key
-  fpm_layer_key         = local.bref_major == 3 ? local.runtime_layer_key : "${local.runtime_layer_key}-fpm"
-  console_layer_key     = local.bref_major == 3 ? local.runtime_layer_key : "${local.bref_layer_name_prefix}console"
+  cpu_prefix         = var.cpu_type == "arm64" ? "arm-" : ""
+  runtime_layer_key  = "${local.bref_layer_name_prefix}${local.cpu_prefix}php-${local.php_version_normalized}"
+  function_layer_key = local.runtime_layer_key
+  fpm_layer_key      = local.bref_major == 3 ? local.runtime_layer_key : "${local.runtime_layer_key}-fpm"
+  console_layer_key  = local.bref_major == 3 ? local.runtime_layer_key : "${local.bref_layer_name_prefix}console"
 
   # Get the layer versions for the specified region
   function_layer_version = lookup(lookup(local.layer_versions, local.function_layer_key, {}), var.aws_region, null)

--- a/examples/v3-php85/main.tf
+++ b/examples/v3-php85/main.tf
@@ -9,7 +9,7 @@ module "bref_layers_v3" {
   aws_region  = "eu-central-1"
 
   # Override to pin a newer Bref v3 catalog if needed.
-  # bref_catalog_url = "https://raw.githubusercontent.com/brefphp/bref/3.0.0-beta2/layers.json"
+  # bref_catalog_url = "https://raw.githubusercontent.com/brefphp/bref/refs/tags/3.0.0/layers.json"
 }
 
 output "v3_results" {


### PR DESCRIPTION
## Summary
- switch the default v3 catalog URL from `3.0.0-beta2` to stable `3.0.0`
- update README and `examples/v3-php85/main.tf` override examples to match
- add changelog entry for the catalog default update

## Why
`bref_catalog_url` already supports overrides, but callers that do not override currently resolve to beta-era v3 layer versions.

## Changes
- `data.tf`: default `bref_catalog_url` for `bref_major == 3` now points to:
  - `https://raw.githubusercontent.com/brefphp/bref/refs/tags/3.0.0/layers.json`
- `README.md`: updated v3 override snippet and data source section
- `examples/v3-php85/main.tf`: updated override snippet
- `CHANGELOG.md`: added `1.2.0` entry

## Validation
- `terraform fmt -recursive`
- `terraform validate` (module root)
- `terraform init -input=false && terraform validate && terraform plan -input=false` in:
  - `examples/basic`
  - `examples/v3-php85`
  - `examples/with-extensions`

All checks passed.
